### PR TITLE
update url to use the official loadbalanced link

### DIFF
--- a/Casks/kicad-nightly.rb
+++ b/Casks/kicad-nightly.rb
@@ -2,9 +2,9 @@ cask "kicad-nightly" do
   version "universal-20240705-1023-a1b4e09cec"
   sha256 "b84e534ec34b3a7548f115d0a11b2b1ab7399cd5b7741b1357fc3c582d278552"
 
-  url "https://kicad-downloads.s3.cern.ch/osx/nightly/kicad-unified-#{version}.dmg",
-      verified: "kicad-downloads.s3.cern.ch/"
-  appcast "https://kicad-downloads.s3.cern.ch/?delimiter=/&prefix=osx/nightly/"
+  url "https://downloads.kicad.org/kicad/macos/explore/nightlies/download/kicad-unified-#{version}.dmg",
+      verified: "downloads.kicad.org/"
+  appcast "https://downloads.kicad.org/?delimiter=/&prefix=osx/nightly/"
   name "KiCad"
   desc "Electronics design automation suite"
   homepage "https://kicad.org/"

--- a/Casks/kicad-nightly.rb
+++ b/Casks/kicad-nightly.rb
@@ -4,7 +4,6 @@ cask "kicad-nightly" do
 
   url "https://downloads.kicad.org/kicad/macos/explore/nightlies/download/kicad-unified-#{version}.dmg",
       verified: "downloads.kicad.org/"
-  appcast "https://downloads.kicad.org/?delimiter=/&prefix=osx/nightly/"
   name "KiCad"
   desc "Electronics design automation suite"
   homepage "https://kicad.org/"


### PR DESCRIPTION
update url to use the official loadbalanced link

if there is any reason the cern cdn link is specifically used instead please let me know, 
if there isnt any particular reason using the loadbalanced official link will error towards more performance for people physically away from the cern cdn servers